### PR TITLE
fix: Fix issue where the label is not translated

### DIFF
--- a/resources/lang/fr/default.php
+++ b/resources/lang/fr/default.php
@@ -1,8 +1,8 @@
 <?php
 
 return [
-    'heading' => 'Verouillé',
-    'user_menu_title' => 'Vérouiller',
+    'heading' => 'Verrouillé',
+    'user_menu_title' => 'Verrouiller',
     'fields' => [
         'password' => 'Mot de passe',
     ],

--- a/src/Lockscreen.php
+++ b/src/Lockscreen.php
@@ -39,7 +39,7 @@ class Lockscreen implements Plugin
 
         $panel->userMenuItems([
             'lockscreen' => MenuItem::make()
-                ->label(__('filament-lockscreen::default.user_menu_title'))
+                ->label(fn () => __('filament-lockscreen::default.user_menu_title'))
                 ->url(route("lockscreen.{$panel->getId()}.page"))
                 ->icon(config('filament-lockscreen.icon')),
         ]);


### PR DESCRIPTION
When using a Language switcher plugin in filament, the lockscreen plugin migth boot first which means the language is not yet set. 

Using a closure for the label fixes the issue and translate the label on the display time, where the language is set.

Also a small French typo fix :-)