### PR TITLE
adds activity timeout to version 2.x

### DIFF
--- a/config/filament-lockscreen.php
+++ b/config/filament-lockscreen.php
@@ -36,5 +36,5 @@ return [
         'force_logout' => false,
     ],
 
-    'activity_timeout' => 60 * 10, // 10 minutes
+    'activity_timeout' => 60 * 30, // 30 minutes
 ];

--- a/config/filament-lockscreen.php
+++ b/config/filament-lockscreen.php
@@ -35,4 +35,6 @@ return [
         'rate_limit_max_count' => 5, // max count for failure login allowed.
         'force_logout' => false,
     ],
+
+    'activity_timeout' => 60 * 10, // 10 minutes
 ];

--- a/src/Http/Livewire/LockerScreen.php
+++ b/src/Http/Livewire/LockerScreen.php
@@ -108,6 +108,7 @@ class LockerScreen extends BasePage
 
         // redirect to the main page and forge the lockscreen session
         session()->forget('lockscreen');
+        session()->forget('locker_last_activity');
         session()->regenerate();
         if (config('filament-lockscreen.enable_redirect_to')) {
             return redirect()->route(config('filament-lockscreen.redirect_route'));

--- a/src/Http/Middleware/LockerTimer.php
+++ b/src/Http/Middleware/LockerTimer.php
@@ -13,13 +13,18 @@ class LockerTimer
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      */
-    public function handle($request, Closure $next)
+    public function handle(Request $request, Closure $next)
     {
-        if ($request->method() === 'GET' && $request->session()->get('locker_last_activity') && (time() - $request->session()->get('locker_last_activity')) > config('filament-lockscreen.activity_timeout', 0)) {
-            $request->session()->put('lockscreen', true);
-        }
+        if (!$request->session()->has('lockscreen')) {
+            $lastActivity = $request->session()->get('locker_last_activity');
+            $activityTimeout =  config('filament-lockscreen.activity_timeout', 60 * 30 /* 30 minutes */);
 
-        $request->session()->put('locker_last_activity', time());
+            if ($request->method() === 'GET' && $lastActivity && (time() - $lastActivity) > $activityTimeout) {
+                $request->session()->put('lockscreen', true);
+            }
+
+            $request->session()->put('locker_last_activity', time());
+        }
 
         return $next($request);
     }

--- a/src/Http/Middleware/LockerTimer.php
+++ b/src/Http/Middleware/LockerTimer.php
@@ -15,7 +15,7 @@ class LockerTimer
      */
     public function handle($request, Closure $next)
     {
-        if ($request->method() === 'GET' && $request->session()->get('locker_last_activity') && (time() - $request->session()->get('locker_last_activity')) > config('filament-lockscreen.activity_timeout')) {
+        if ($request->method() === 'GET' && $request->session()->get('locker_last_activity') && (time() - $request->session()->get('locker_last_activity')) > config('filament-lockscreen.activity_timeout', 0)) {
             $request->session()->put('lockscreen', true);
         }
 

--- a/src/Http/Middleware/LockerTimer.php
+++ b/src/Http/Middleware/LockerTimer.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace lockscreen\FilamentLockscreen\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+class LockerTimer
+{
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function handle($request, Closure $next)
+    {
+        if ($request->method() === 'GET' && $request->session()->get('locker_last_activity') && (time() - $request->session()->get('locker_last_activity')) > config('filament-lockscreen.activity_timeout')) {
+            $request->session()->put('lockscreen', true);
+        }
+
+        $request->session()->put('locker_last_activity', time());
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
This PR adds the ability to add a timeout to automatically lock session if no activity after a set duration of time. 


usage 

```php 
//
use lockscreen\FilamentLockscreen\Http\Middleware\LockerTimer;

//

 $panel->middleware([
      //
      LockerTimer::class,
  ])
```