### PR TITLE
redirect guest user to the login page of current panel, or default panel if current panel could not be detected.

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -22,7 +22,7 @@ Route::name('lockscreen.')
                                 ? config('filament-lockscreen.url')
                                 : '/screen/lock',
                             LockerScreen::class
-                        )->name('page')->middleware(['auth']);
+                        )->name('page');
                     });
 
             }

--- a/src/Http/Livewire/LockerScreen.php
+++ b/src/Http/Livewire/LockerScreen.php
@@ -37,11 +37,15 @@ class LockerScreen extends BasePage
     public function mount()
     {
         // Check if the request is still authenticated or not before rendering the page,
-        // if not authenticated then redirect to the default filament login page
+        // if not authenticated then redirect to the login page of current panel, or default panel if current panel could not be detected.
 
-        if(!Filament::auth()->check())
+        if (!Filament::auth()->check())
         {
-            return redirect(Filament::getDefaultPanel()->getLoginUrl());
+            if (filament()->getCurrentPanel()) {
+                return redirect(filament()->getCurrentPanel()->getLoginUrl());
+            }
+
+            return redirect(filament()->getDefaultPanel()->getLoginUrl());
         }
 
         session(['lockscreen' => true]);


### PR DESCRIPTION
Issue:
If guest use try to access lock screen page (accidentally), the `Route [login] not defined
` exception would be raised.

Also without the `auth` middleware, the guest user redirects to the default panel, not the current panel.