### PR TITLE
Implement Path matching logic for preventing blocking other non-panel path request.

### DIFF
--- a/src/Http/Middleware/Locker.php
+++ b/src/Http/Middleware/Locker.php
@@ -3,24 +3,50 @@
 namespace lockscreen\FilamentLockscreen\Http\Middleware;
 
 use Closure;
-use Psr\Container\ContainerExceptionInterface;
-use Psr\Container\NotFoundExceptionInterface;
+use Exception;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Livewire\LivewireManager;
 
 class Locker
 {
     /**
-     * @throws ContainerExceptionInterface
-     * @throws NotFoundExceptionInterface
-     * @throws \Exception
+     * @param Request $request
+     * @param Closure $next
+     * @return RedirectResponse|mixed
+     *
+     * @throws Exception
      */
-    public function handle($request, Closure $next)
+    public function handle(Request $request, Closure $next): mixed
     {
-        if ($request->method() === 'GET' && $request->session()->get('lockscreen')) {
+        if ($this->isLivewireRequest()) {
+            return $next($request);
+        }
+
+        if ($request->isMethod('GET') && $request->session()->get('lockscreen') && $this->isSegmentMatched($request)) {
             $panelId = filament()->getCurrentPanel()?->getId();
 
             return redirect()->route("lockscreen.{$panelId}.page");
         }
 
         return $next($request);
+    }
+
+    /**
+     * @param $request
+     * @return boolean
+     */
+    protected function isSegmentMatched($request): bool
+    {
+        $panelPath = filament()->getCurrentPanel()?->getPath();
+        $guardLockPath = Str::of($panelPath)->remove('/');
+
+        return $request->is([$guardLockPath, $guardLockPath->append('/*')]);
+    }
+
+    protected function isLivewireRequest(): bool
+    {
+        return class_exists(LivewireManager::class) && app(LivewireManager::class)->isLivewireRequest();
     }
 }


### PR DESCRIPTION
This PR helps to filter only the path that belongs to the Filament Panel on where the plugin is installed by using Path Matching.

![vivaldi_lEjRNPv98a](https://github.com/user-attachments/assets/b79ae654-b18a-4173-b99c-7207776c6293)
