### PR TITLE
Support Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "danharrin/livewire-rate-limiting": "^1.0|^2.1.0",
         "filament/filament": "^v3.0",
         "spatie/laravel-package-tools": "^1.13.0",
-        "illuminate/support": "^10.0|^11.0|^12.0"
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0"
 
     },
     "require-dev": {


### PR DESCRIPTION
Adds Laravel 13 support to the `2.x` (Filament v3) line by widening the `illuminate/support` constraint, mirroring #80 which added Laravel 12 support.

## Summary
- `illuminate/support`: `^10.0|^11.0|^12.0` → `^10.0|^11.0|^12.0|^13.0`

No code changes are required — the package only uses stable `illuminate/support` helpers and Filament v3 APIs, none of which changed in Laravel 13.