### PR TITLE
refactor: enhance session idle management and prevent premature locking

### DIFF
--- a/src/Concerns/HasSessionIdle.php
+++ b/src/Concerns/HasSessionIdle.php
@@ -6,9 +6,9 @@ use lockscreen\FilamentLockscreen\Lockscreen;
 
 trait HasSessionIdle
 {
-    protected bool $enableActivityTimeout = true;
+    protected bool $enableActivityTimeout = false;
 
-    protected int $activityTimeout;
+    protected int $activityTimeout = 1800;
 
     /**
      * @param  int  $seconds  The number of seconds of inactivity before the screen automatically locks. Defaults to 1800 (30 minutes)
@@ -41,10 +41,10 @@ trait HasSessionIdle
     }
 
     /**
-     * @return int Idle Timeout in Minutes
+     * @return int Idle Timeout in Seconds
      */
     public function getIdleTimeout(): int
     {
-        return $this->activityTimeout ?? 30;
+        return $this->activityTimeout;
     }
 }

--- a/src/Http/Livewire/LockerScreen.php
+++ b/src/Http/Livewire/LockerScreen.php
@@ -109,16 +109,17 @@ class LockerScreen extends SimplePage
         }
 
         // redirect to the main page and forge the lockscreen session
-        session()->regenerate();
-        $this->purgeSession();
+
+        $this->sessionRegenerate();
 
         return redirect()->intended();
     }
 
-    protected function purgeSession(): void
+    protected function sessionRegenerate(): void
     {
-        session()->forget('lockscreen');
-        session()->forget('session_last_activity');
+        session()->regenerate();
+        session()->put('lockscreen', false);
+        session()->put('session_last_activity', time());
     }
 
     protected function getRateLimitedNotification(TooManyRequestsException $exception): ?Notification

--- a/src/Http/Middleware/Locker.php
+++ b/src/Http/Middleware/Locker.php
@@ -26,7 +26,7 @@ class Locker
         /**
          *  Normal Lock session
          */
-        if ($request->isMethod('GET') && $request->session()->get('lockscreen') && $this->isSegmentMatched($request)) {
+        if ($request->isMethod('GET') && ($request->session()->get('lockscreen') &&  (boolean) $request->session()->get('lockscreen') === true) && $this->isSegmentMatched($request)) {
             $panelId = filament()->getCurrentPanel()?->getId();
 
             redirect()->setIntendedUrl(url()->previous() ?? filament()->getDefaultPanel()->getPath());
@@ -45,6 +45,10 @@ class Locker
 
             if ($lastActivity && (time() - $lastActivity) > $idleTimeout) {
                 $request->session()->put('lockscreen', true);
+                $request->session()->put('session_last_activity', time());
+
+                $panelId = filament()->getCurrentPanel()?->getId();
+                return to_route("lockscreen.{$panelId}.page");
             }
 
             $request->session()->put('session_last_activity', time());


### PR DESCRIPTION
## Summary
This PR improves the session idle timeout logic and refines how the lockscreen state is managed within the session. It ensures that the idle timeout is disabled by default and fixes issues where the lockscreen could be triggered unexpectedly or fail to redirect correctly upon timeout.

## Changes
- **Configuration Defaults**: 
    - Changed `enableActivityTimeout` default to `false` in `HasSessionIdle`.
    - Set default `activityTimeout` to `1800` seconds (30 minutes) and updated documentation/return types to consistently reflect seconds instead of minutes.
- **Session Management**:
    - Replaced `purgeSession()` with `sessionRegenerate()` in `LockerScreen`. This new method explicitly sets `lockscreen` to `false` and initializes `session_last_activity` upon successful login/unlock, providing a cleaner session state.
- **Middleware Logic**:
    - Enhanced the `Locker` middleware to strictly validate the `lockscreen` session value as a boolean.
    - Added an immediate redirect to the lockscreen page when an idle timeout is detected, ensuring the user is prompted for credentials as soon as the session expires.
    - Updated `session_last_activity` when locking the screen to prevent immediate re-triggering loops.

## Impact
These changes provide a more stable and predictable behavior for the idle timeout feature, preventing it from interfering with the user experience unless explicitly enabled and correctly configured.